### PR TITLE
fixed JSON parsing for Fps (int to float64)

### DIFF
--- a/info.go
+++ b/info.go
@@ -58,7 +58,7 @@ type Info struct {
 		Ext         string      `json:"ext"`
 		FormatNote  string      `json:"format_note"`
 		Acodec      string      `json:"acodec"`
-		Abr         float32         `json:"abr,omitempty"`
+		Abr         float32     `json:"abr,omitempty"`
 		Container   string      `json:"container,omitempty"`
 		FormatID    string      `json:"format_id"`
 		URL         string      `json:"url"`
@@ -111,7 +111,7 @@ type Info struct {
 		Width       int         `json:"width,omitempty"`
 		Tbr         float64     `json:"tbr"`
 		Asr         interface{} `json:"asr,omitempty"`
-		Fps         int         `json:"fps,omitempty"`
+		Fps         float64     `json:"fps,omitempty"`
 		Language    interface{} `json:"language,omitempty"`
 		Filesize    int         `json:"filesize"`
 		Acodec      string      `json:"acodec"`
@@ -124,20 +124,20 @@ type Info struct {
 			AcceptEncoding string `json:"Accept-Encoding"`
 			AcceptLanguage string `json:"Accept-Language"`
 		} `json:"http_headers"`
-		PlayerURL string `json:"player_url,omitempty"`
-		Abr       float32    `json:"abr,omitempty"`
+		PlayerURL string  `json:"player_url,omitempty"`
+		Abr       float32 `json:"abr,omitempty"`
 	} `json:"requested_formats"`
 	Format         string      `json:"format"`
 	FormatID       string      `json:"format_id"`
 	Width          int         `json:"width"`
 	Height         int         `json:"height"`
 	Resolution     interface{} `json:"resolution"`
-	Fps            int         `json:"fps"`
+	Fps            float64     `json:"fps"`
 	Vcodec         string      `json:"vcodec"`
 	Vbr            interface{} `json:"vbr"`
 	StretchedRatio interface{} `json:"stretched_ratio"`
 	Acodec         string      `json:"acodec"`
-	Abr            float32         `json:"abr"`
+	Abr            float32     `json:"abr"`
 	Ext            string      `json:"ext"`
 	Fulltitle      string      `json:"fulltitle"`
 	Filename       string      `json:"_filename"`


### PR DESCRIPTION
https://www.youtube.com/watch?v=5g-W0J405q0 was failing to marshal `Fps`

```
json: cannot unmarshal number 24.0 into Go struct field .requested_formats.fps of type int
```

This updates the field to be a float